### PR TITLE
Debug zellij layout script

### DIFF
--- a/run-zellij-xp.sh
+++ b/run-zellij-xp.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-export PATH=bin:$PATH
-export ZELLIJ_CONFIG_DIR=zellij-config
-exec zellij/target/release/zellij --layout zellij-config/layouts/windows_xp.kdl "$@"
+
+# Get the script's directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+export PATH="$SCRIPT_DIR/bin:$PATH"
+export ZELLIJ_CONFIG_DIR="$SCRIPT_DIR/zellij-config"
+
+# Use absolute path for the layout
+LAYOUT_PATH="$SCRIPT_DIR/zellij-config/layouts/windows_xp.kdl"
+
+exec "$SCRIPT_DIR/bin/zellij" --layout "$LAYOUT_PATH" "$@"

--- a/zellij-config/taskbar_launcher.sh
+++ b/zellij-config/taskbar_launcher.sh
@@ -26,7 +26,7 @@ launch_float() {
   echo "$id" > "$counter_file"
   name="float-$id"
   grep -qxF "$name" "$list_file" || echo "$name" >> "$list_file"
-  zellij/target/release/zellij run --floating --pinned --name "$name" -- zellij-config/float_shell.sh || true
+  zellij run --floating --pinned --name "$name" -- zellij-config/float_shell.sh || true
 }
 
 launch_term() {
@@ -34,7 +34,7 @@ launch_term() {
   echo "$id" > "$counter_file"
   name="term-$id"
   grep -qxF "$name" "$list_file" || echo "$name" >> "$list_file"
-  zellij/target/release/zellij run --floating --pinned --name "$name" -- ${SHELL:-bash} || true
+  zellij run --floating --pinned --name "$name" -- ${SHELL:-bash} || true
 }
 
 clear


### PR DESCRIPTION
Fix `run-zellij-xp.sh` to correctly start Zellij with the custom layout by correcting binary paths and improving path resolution.

The original script failed to apply the custom Zellij layout because it was looking for the `zellij` binary in `zellij/target/release/zellij` instead of `bin/zellij`. The `taskbar_launcher.sh` script, used by the layout, also contained the same incorrect path. This PR corrects these paths and ensures all necessary files are found using absolute paths derived from the script's location.

---
<a href="https://cursor.com/background-agent?bcId=bc-29be469f-0cd3-4615-a60e-556608ef36b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29be469f-0cd3-4615-a60e-556608ef36b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

